### PR TITLE
Indent rules conflict between eslint / prettier with jest test `it.each`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2020-02-04
+
+### Fixed
+
+- indent rules conflict between eslint / prettier with jest test `it.each`
+
 ## [1.2.0] - 2020-01-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojob/eslint-config",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ESLint config for TypeScript projects at Gojob",
   "main": "index.js",
   "repository": "https://github.com/gojob-1337/eslint-config",

--- a/typescript.js
+++ b/typescript.js
@@ -13,7 +13,7 @@ module.exports = {
   rules: {
     semi: ["error", "always"],
     "prettier/prettier": ["error", { singleQuote: true }],
-    "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/indent": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/prefer-interface": "off",
     "@typescript-eslint/explicit-member-accessibility": "off",


### PR DESCRIPTION
Proposal: let prettier do the indentation

Closes #5 