### PR TITLE
chore: handle floating promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ At the present time, the ESLint plugin for VSCode has difficulties parsing/fixin
   "typescript.tsdk": "node_modules/typescript/lib"
 }
 ```
+
+### FAQ
+
+Q: I get the following error:
+```Error while loading rule '@typescript-eslint/no-floating-promises': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.```
+
+A: You need to add ```json parserOptions: { project: "<my-ts-config>.json" }``` in your eslint config file, i.e. ```json parserOptions: { project: "./tsconfig.json" }```.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojob/eslint-config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ESLint config for TypeScript projects at Gojob",
   "main": "index.js",
   "repository": "https://github.com/gojob-1337/eslint-config",

--- a/typescript-react.js
+++ b/typescript-react.js
@@ -8,7 +8,7 @@ module.exports = {
     "prettier/react",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "react-hooks", "simple-import-sort"],
@@ -27,24 +27,33 @@ module.exports = {
     "@typescript-eslint/no-non-null-assertion": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "simple-import-sort/sort": ["error", {
-      "groups": [
-        // `react` related packages come first.
-        ["^react$", "^react-dom$"],
-        // Internal packages. And "Side effect imports" (polluting namespace)
-        ["^@?\\w", "^\\u0000"],
-        // Parent imports (put `..` last). And other relative imports (put `.` last).
-        ["^\\.\\.(?!/?$)", "^\\.\\./?$", "^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
-        // Style imports.
-        ["^.+\\.s?css$"],
-      ]
-    }],
+    "simple-import-sort/sort": [
+      "error",
+      {
+        groups: [
+          // `react` related packages come first.
+          ["^react$", "^react-dom$"],
+          // Internal packages. And "Side effect imports" (polluting namespace)
+          ["^@?\\w", "^\\u0000"],
+          // Parent imports (put `..` last). And other relative imports (put `.` last).
+          [
+            "^\\.\\.(?!/?$)",
+            "^\\.\\./?$",
+            "^\\./(?=.*/)(?!/?$)",
+            "^\\.(?!/?$)",
+            "^\\./?$",
+          ],
+          // Style imports.
+          ["^.+\\.s?css$"],
+        ],
+      },
+    ],
     "sort-imports": "off",
-    "import/order": "off"
+    "import/order": "off",
   },
   settings: {
     react: {
-      version: "detect"
-    }
-  }
+      version: "detect",
+    },
+  },
 };

--- a/typescript.js
+++ b/typescript.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    'eslint:recommended',
+    "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "prettier",
     "plugin:prettier/recommended",
@@ -20,9 +20,10 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-floating-promises": ["error"],
     "@typescript-eslint/member-ordering": 2,
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "simple-import-sort/sort": "error",
     "sort-imports": "off",
-  }
+  },
 };


### PR DESCRIPTION
Create an error during linting when 'await' keywords have been forgotten.
Can be disable when the await is not required by using 'void' keyword or by disabling rule with a comment.